### PR TITLE
Remove unused dependencies and Hilt plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     implementation libs.kotlin.stdlib
 
     implementation libs.androidx.activity
+    implementation libs.androidx.appcompat
     implementation libs.androidx.constraintlayout
-    implementation libs.androidx.core
     implementation libs.androidx.fragment
 
     implementation libs.androidx.work.runtime
@@ -51,9 +51,6 @@ dependencies {
 
     implementation libs.androidx.lifecycle.viewmodel.ktx
     implementation libs.androidx.lifecycle.service
-    implementation libs.androidx.lifecycle.process
-
-    implementation libs.android.material
 
     testImplementation libs.junit
     androidTestImplementation libs.test.ext.junit

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar"
+        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
         tools:ignore="DataExtractionRules">
         <activity
             android:name=".ExampleActivity"

--- a/core-compose/build.gradle
+++ b/core-compose/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'example.android.library'
     id 'example.android.compose'
-    id 'example.android.hilt'
 }
 
 android {
@@ -12,8 +11,6 @@ android {
 }
 
 dependencies {
-    implementation libs.androidx.core
-
     implementation libs.compose.foundation
     implementation libs.compose.material
 

--- a/core-kotlin/build.gradle
+++ b/core-kotlin/build.gradle
@@ -12,7 +12,6 @@ android {
 
 dependencies {
     implementation libs.coroutines.android
-    implementation libs.androidx.core
 
     testImplementation libs.junit
     androidTestImplementation libs.test.ext.junit

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -12,7 +12,6 @@ android {
 
 dependencies {
     implementation project(':core-kotlin')
-    implementation libs.androidx.core
 
     testImplementation libs.junit
     androidTestImplementation libs.test.ext.junit

--- a/feature-bar-api/build.gradle
+++ b/feature-bar-api/build.gradle
@@ -10,10 +10,6 @@ android {
 }
 
 dependencies {
-    implementation libs.androidx.constraintlayout
-    implementation libs.androidx.core
-    implementation libs.android.material
-
     testImplementation libs.junit
     androidTestImplementation libs.test.ext.junit
     androidTestImplementation libs.test.espresso.core

--- a/feature-bar-impl/build.gradle
+++ b/feature-bar-impl/build.gradle
@@ -17,7 +17,6 @@ dependencies {
 
     implementation libs.androidx.activity
     implementation libs.androidx.constraintlayout
-    implementation libs.androidx.core
     implementation libs.androidx.lifecycle.viewmodel.ktx
 
     testImplementation libs.junit

--- a/feature-compose/build.gradle
+++ b/feature-compose/build.gradle
@@ -14,8 +14,6 @@ android {
 dependencies {
     implementation project(':core-compose')
     implementation project(':feature-bar-api')
-    implementation libs.androidx.core
-
     implementation libs.compose.foundation
     implementation libs.compose.material
     implementation libs.androidx.navigation.compose

--- a/feature-foo-api/build.gradle
+++ b/feature-foo-api/build.gradle
@@ -10,10 +10,6 @@ android {
 }
 
 dependencies {
-    implementation libs.androidx.constraintlayout
-    implementation libs.androidx.core
-    implementation libs.android.material
-
     testImplementation libs.junit
     androidTestImplementation libs.test.ext.junit
     androidTestImplementation libs.test.espresso.core

--- a/feature-foo-impl/build.gradle
+++ b/feature-foo-impl/build.gradle
@@ -16,7 +16,6 @@ dependencies {
 
     implementation libs.androidx.activity
     implementation libs.androidx.constraintlayout
-    implementation libs.androidx.core
     implementation libs.androidx.lifecycle.viewmodel.ktx
 
     testImplementation libs.junit

--- a/feature-navigation-compose/build.gradle
+++ b/feature-navigation-compose/build.gradle
@@ -14,8 +14,6 @@ android {
 dependencies {
     implementation project(':core-compose')
     implementation project(':feature-bar-api')
-    implementation libs.androidx.core
-
     implementation libs.compose.foundation
     implementation libs.compose.material
     implementation libs.androidx.navigation.compose

--- a/feature-navigation-fragment/build.gradle
+++ b/feature-navigation-fragment/build.gradle
@@ -13,8 +13,6 @@ android {
 dependencies {
     implementation project(':feature-bar-api')
 
-    implementation libs.androidx.core
-    implementation libs.androidx.constraintlayout
     implementation libs.androidx.fragment
 
     implementation libs.androidx.navigation.fragment

--- a/feature-work-api/build.gradle
+++ b/feature-work-api/build.gradle
@@ -10,8 +10,6 @@ android {
 }
 
 dependencies {
-    implementation libs.androidx.core
-
     testImplementation libs.junit
     androidTestImplementation libs.test.ext.junit
     androidTestImplementation libs.test.espresso.core

--- a/feature-work-impl/build.gradle
+++ b/feature-work-impl/build.gradle
@@ -14,8 +14,6 @@ dependencies {
     implementation project(':feature-bar-api')
     implementation project(':feature-work-api')
 
-    implementation libs.androidx.core
-
     implementation libs.androidx.work.runtime
     implementation libs.androidx.hilt.work
     ksp libs.androidx.hilt.compiler

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 
 android-gradle = "9.0.1"
-android-material = "1.12.0"
 
 kotlin = "2.3.10"
 ksp = "2.3.6"
@@ -10,7 +9,6 @@ coroutines = "1.10.2"
 androidx-activity = "1.12.4"
 androidx-appcompat = "1.7.1"
 androidx-constraintlayout = "2.2.1"
-androidx-core = "1.17.0"
 androidx-fragment = "1.8.9"
 androidx-hilt = "1.3.0"
 androidx-lifecycle = "2.10.0"
@@ -28,7 +26,6 @@ test-espresso = "3.7.0"
 [libraries]
 
 android-pluginGradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
-android-material = { module = "com.google.android.material:material", version.ref = "android-material" }
 
 kotlin-pluginGradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-composePluginGradle = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
@@ -44,7 +41,6 @@ coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
-androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidx-hilt" }
@@ -56,7 +52,6 @@ androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-view
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "androidx-lifecycle" }
-androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "androidx-lifecycle" }
 
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }


### PR DESCRIPTION
## Summary
- Remove `android-material` dependency from all modules and switch app theme from `MaterialComponents` to `AppCompat`
- Remove unused `androidx-core` from all 13 modules (not directly imported anywhere)
- Remove unused `androidx-lifecycle-process` from app module
- Remove unused `androidx-constraintlayout` from API/fragment modules that had no layout XML usage
- Remove unnecessary `example.android.hilt` plugin from `core-compose` (no Hilt annotations used)
- Clean up version catalog entries (`android-material`, `androidx-core`, `lifecycle-process`)

## Test plan
- [ ] Verify the project builds successfully
- [ ] Verify all sample screens render correctly with AppCompat theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)