### PR TITLE
Migrate hiltViewModel to hilt-lifecycle-viewmodel-compose

### DIFF
--- a/feature-compose/build.gradle
+++ b/feature-compose/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation libs.compose.foundation
     implementation libs.compose.material
     implementation libs.androidx.navigation.compose
-    implementation libs.androidx.hilt.navigation.compose
+    implementation libs.androidx.hilt.lifecycle.viewmodel.compose
 
     testImplementation libs.junit
     androidTestImplementation libs.test.ext.junit

--- a/feature-navigation-compose/build.gradle
+++ b/feature-navigation-compose/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation libs.compose.foundation
     implementation libs.compose.material
     implementation libs.androidx.navigation.compose
-    implementation libs.androidx.hilt.navigation.compose
+    implementation libs.androidx.hilt.lifecycle.viewmodel.compose
 
     testImplementation libs.junit
     androidTestImplementation libs.test.ext.junit

--- a/feature-navigation-compose/src/main/java/io/github/fornewid/feature/navigation/compose/ExampleNavGraph.kt
+++ b/feature-navigation-compose/src/main/java/io/github/fornewid/feature/navigation/compose/ExampleNavGraph.kt
@@ -2,7 +2,7 @@ package io.github.fornewid.feature.navigation.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "
 
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidx-hilt" }
 androidx-hilt-navigation-fragment = { module = "androidx.hilt:hilt-navigation-fragment", version.ref = "androidx-hilt" }
-androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidx-hilt" }
+androidx-hilt-lifecycle-viewmodel-compose = { module = "androidx.hilt:hilt-lifecycle-viewmodel-compose", version.ref = "androidx-hilt" }
 androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidx-hilt" }
 
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
## Summary
- deprecated된 `androidx.hilt:hilt-navigation-compose`를 `androidx.hilt:hilt-lifecycle-viewmodel-compose`로 마이그레이션
- `hiltViewModel()` import를 `androidx.hilt.lifecycle.viewmodel.compose` 패키지로 변경
- `feature-compose`, `feature-navigation-compose` 모듈의 의존성 업데이트

## Test plan
- [ ] `feature-navigation-compose` 모듈 빌드 확인 (deprecation 경고 제거)
- [ ] `feature-compose` 모듈 빌드 확인
- [ ] Navigation Compose 샘플 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)