### PR TITLE
Add buildconfig and buildconfig-stub modules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,13 @@ android {
     buildFeatures {
         viewBinding true
     }
+
+    flavorDimensions "default"
+    productFlavors {
+        dev {}
+        stage {}
+        real {}
+    }
 }
 
 // Turn ON enableAggregatingTask by default in Dagger Hilt 2.40
@@ -37,6 +44,8 @@ dependencies {
     implementation project(':feature:navigation:compose')
 
     implementation project(':feature:compose')
+
+    implementation project(':buildconfig')
 
     implementation libs.kotlin.stdlib
 

--- a/buildconfig-stub/build.gradle
+++ b/buildconfig-stub/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'example.android.library'
+}
+
+android {
+    namespace 'io.github.fornewid.dagger.hilt.example.buildconfig'
+
+    defaultConfig {
+        buildConfigField "String", "VERSION_NAME", "String.valueOf(\"\")"
+        buildConfigField "String", "API_BASE_URL", "String.valueOf(\"\")"
+    }
+
+    buildFeatures {
+        buildConfig true
+    }
+
+    // productFlavors 없음 — flavor 전파 방지
+}

--- a/buildconfig-stub/src/main/AndroidManifest.xml
+++ b/buildconfig-stub/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/buildconfig/build.gradle
+++ b/buildconfig/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'example.android.library'
+}
+
+android {
+    namespace 'io.github.fornewid.dagger.hilt.example.buildconfig'
+
+    defaultConfig {
+        buildConfigField "String", "VERSION_NAME", "String.valueOf(\"1.0\")"
+    }
+
+    buildFeatures {
+        buildConfig true
+    }
+
+    flavorDimensions "default"
+    productFlavors {
+        dev {
+            buildConfigField "String", "API_BASE_URL", "String.valueOf(\"https://dev.example.com\")"
+        }
+        stage {
+            buildConfigField "String", "API_BASE_URL", "String.valueOf(\"https://stage.example.com\")"
+        }
+        real {
+            buildConfigField "String", "API_BASE_URL", "String.valueOf(\"https://real.example.com\")"
+        }
+    }
+}

--- a/buildconfig/src/main/AndroidManifest.xml
+++ b/buildconfig/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -13,6 +13,8 @@ android {
 dependencies {
     implementation project(':core:kotlin')
 
+    compileOnly project(':buildconfig-stub')
+
     testImplementation libs.junit
     androidTestImplementation libs.test.ext.junit
     androidTestImplementation libs.test.espresso.core

--- a/data/src/main/java/io/github/fornewid/data/ExampleRepository.kt
+++ b/data/src/main/java/io/github/fornewid/data/ExampleRepository.kt
@@ -17,7 +17,9 @@ internal class ExampleRepositoryImpl @Inject constructor(
     override suspend fun getSomething(): String {
         return withContext(ioDispatcher) {
             delay(500)
-            "something"
+            // BuildConfig는 buildconfig-stub(compileOnly)로 컴파일되고,
+            // 런타임에는 app이 가져오는 buildconfig 모듈의 실제 값으로 교체됨.
+            "something from ${io.github.fornewid.dagger.hilt.example.buildconfig.BuildConfig.API_BASE_URL}"
         }
     }
 }

--- a/data/src/main/java/io/github/fornewid/data/ExampleRepository.kt
+++ b/data/src/main/java/io/github/fornewid/data/ExampleRepository.kt
@@ -1,6 +1,7 @@
 package io.github.fornewid.data
 
 import io.github.fornewid.core.kotlin.IoDispatcher
+import io.github.fornewid.dagger.hilt.example.buildconfig.BuildConfig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -19,7 +20,7 @@ internal class ExampleRepositoryImpl @Inject constructor(
             delay(500)
             // BuildConfig는 buildconfig-stub(compileOnly)로 컴파일되고,
             // 런타임에는 app이 가져오는 buildconfig 모듈의 실제 값으로 교체됨.
-            "something from ${io.github.fornewid.dagger.hilt.example.buildconfig.BuildConfig.API_BASE_URL}"
+            "something from ${BuildConfig.API_BASE_URL}"
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Disable BuildConfig generation by default.
+# Only modules that explicitly set buildFeatures.buildConfig = true will generate it.
+android.defaults.buildfeatures.buildconfig=false

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,8 @@ dependencyResolutionManagement {
 }
 
 include ':app'
+include ':buildconfig'
+include ':buildconfig-stub'
 include ':feature:foo:api'
 include ':feature:foo:impl'
 include ':feature:bar:api'


### PR DESCRIPTION
## Summary
- BuildConfig를 별도 모듈로 분리하여 flavor 전파 문제를 해결
- `gradle.properties`에서 기본 BuildConfig 생성 비활성화

## 변경 내용

### 추가된 모듈

**`:buildconfig`** — flavor별 실제 빌드 설정값
- `VERSION_NAME`, `API_BASE_URL` 등 flavor(dev/stage/real)에 따라 달라지는 값 정의
- `buildFeatures.buildConfig = true` 명시

**`:buildconfig-stub`** — flavor 없는 스텁
- 동일한 namespace로 동일한 BuildConfig 필드를 빈 기본값으로 선언
- **flavor 없음** → 하위 모듈에 flavor 전파 방지

### 의존성 구조

```
:data ──compileOnly──▶ :buildconfig-stub (컴파일 시점만, APK에 미포함)
:app  ──implementation──▶ :buildconfig    (런타임에 실제 값 제공)
```

`compileOnly`는 컴파일 시점에만 사용되고 빌드 결과물에 포함되지 않으므로, 런타임에는 app이 가져오는 `:buildconfig`의 실제 flavor 값으로 교체됩니다.

### 기타
- `gradle.properties`에 `android.defaults.buildfeatures.buildconfig=false` 추가
- `app/build.gradle`에 `productFlavors` (dev/stage/real) 추가

## Test plan
- [x] `./gradlew :app:assembleDevDebug` 빌드 성공
- [ ] 런타임에 `BuildConfig.API_BASE_URL` 값이 flavor에 맞게 정상 주입되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)